### PR TITLE
We want to be able to limit the number of connection to the database

### DIFF
--- a/fabfile/env/platforms.py
+++ b/fabfile/env/platforms.py
@@ -157,6 +157,10 @@ env.jormungandr_instance_socket = 'localhost'
 env.jormungandr_default_handler = 'default'
 env.jormungandr_syslog_facility = 'local7'
 
+#used for limiting the number of connections to the database
+#by default we keep the default values
+env.jormungandr_pool_size = None
+
 ##############################
 # kraken
 ##############################

--- a/templates/jormungandr/settings.py.jinja
+++ b/templates/jormungandr/settings.py.jinja
@@ -13,6 +13,11 @@ SQLALCHEMY_DATABASE_URI ='postgresql://{{env.tyr_postgresql_user}}:{{env.tyr_pos
 PUBLIC={{env.jormungandr_is_public}}
 
 
+{% if env.jormungandr_pool_size %}
+#limit the connection pool size of sqlalchemy
+SQLALCHEMY_POOL_SIZE = {{env.jormungandr_pool_size}}
+{% endif %}
+
 # logger configuration
 from jormungandr.logging_utils import IdFilter
 LOGGER = {


### PR DESCRIPTION
In production we have 80 connections to the database, and they are
almost never used since we cache all call to the database, and we don't
have a lot of data in it, only configuration of the instances and
authentication