### PR TITLE
change a bit the get_packages task

### DIFF
--- a/fabfile/custom_tasks.py
+++ b/fabfile/custom_tasks.py
@@ -35,6 +35,8 @@ This file contains some specific tasks not to be run everytime
 import os
 import string
 import random
+import uuid
+from datetime import datetime
 from fabric.colors import red
 from fabric.context_managers import cd, warn_only
 from fabric.contrib.files import exists
@@ -147,8 +149,10 @@ def get_packages(url):
     """
     retrieve debian package to install Navitia by source
     """
-    random_nb = ''.join([random.choice(string.ascii_letters + string.digits) for n in xrange(10)])
-    mktemp = '/tmp/tmp.{}'.format(random_nb)
+    mktemp = '/tmp/navitia_packages_{}'.format(datetime.now().strftime("%Y%m%d-%H%M%S"))
+
+    env.debian_packages_path = mktemp
+
     local("mkdir {mktemp} && cd {mktemp} && wget --no-check-certificate {url}"
           .format(mktemp=mktemp, url=url))
-    local("cd {} && unzip -j archive".format(mktemp))
+    local("cd {} && unzip -j archive.zip".format(mktemp))

--- a/fabfile/env/platforms.py
+++ b/fabfile/env/platforms.py
@@ -40,9 +40,8 @@ env.distrib = 'ubuntu14.04'
 env.KRAKEN_USER = 'www-data'
 env.TYR_USER = env.KRAKEN_USER
 
-#setup
-env.packages_url = 'https://ci.navitia.io/job/navitia_release/lastSuccessfulBuild/artifact/*zip*/archive.zip'
-env.packages_destination = '/tmp'
+# local path to navitia packages
+env.debian_packages_path = None
 
 env.KRAKEN_RABBITMQ_OK_PORT = 5672
 env.KRAKEN_RABBITMQ_WRONG_PORT = 56722

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -69,6 +69,8 @@ def _install_packages(package_filter):
         #it is not optimal, each package will be potentially copied several times, we'll have to improve that
         with temporary_directory() as tmp_dir:
             for package in package_filter:
+                if env.debian_packages_path:
+                    package = "{path}/{package}".format(path=env.debian_packages_path, package=package)
                 put(package, tmp_dir)
             with cd(tmp_dir):
                 with warn_only():#@TODO: catch only on error


### PR DESCRIPTION
now you can do:
`fab  use:artemis packages:"https://ci.navitia.io/job/navitia_release_multi_os/LINUX_DISTRIB\=debian8/lastSuccessfulBuild/artifact/*zip*/archive.zip" version`

to install the last packages

and :
`fab  use:artemis let:debian_packages_path=/tmp/navitia_packages_20160115-140324797357
upgrade_version`

to install packages already downloaded (in they are stored in
/tmp/navitia_pacakges_{datetime}