### PR TITLE
Use the fair optimization profile of celery

### DIFF
--- a/templates/tyr/tyr_worker.jinja
+++ b/templates/tyr/tyr_worker.jinja
@@ -14,7 +14,7 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME=tyr_worker
 DAEMON="/usr/local/bin/celery"
-DAEMON_OPTS="-A tyr.tasks --detach --events worker"
+DAEMON_OPTS="-A tyr.tasks --detach -Ofair --events worker"
 USER={{env.KRAKEN_USER}}
 GROUP={{env.KRAKEN_USER}}
 PID=/tmp/tyr_worker.pid


### PR DESCRIPTION
http://docs.celeryproject.org/en/latest/userguide/optimizing.html

TLDR: we don't want to prefect a lot of message since they will wait
really long for the previous task to finish.

We should wait after the next deployment to prod for merging this PR, it would be nice to test a little on internals platforms.