### PR TITLE
try to fix thread bug

### DIFF
--- a/templates/jormungandr/jormungandr.wsgi.jinja
+++ b/templates/jormungandr/jormungandr.wsgi.jinja
@@ -1,6 +1,10 @@
 #
 ## File managed by fabric, don't edit directly
 #
+
+# this import might fix a strange thread problem: http://bugs.python.org/issue7980
+import _strptime
+
 import os
 try:
     config_file = '{{env.jormungandr_base_dir}}/newrelic.ini'


### PR DESCRIPTION
linked to http://jira.canaltp.fr/browse/NAVITIAII-2047

the import of _strptime does not seems to be thread safe
(http://bugs.python.org/issue7980), so it has to be done before threads
start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canaltp/fabric_navitia/108)
<!-- Reviewable:end -->
