### PR TITLE
fix restart_kraken robustness against wrong wait parameter

### DIFF
--- a/fabfile/component/kraken.py
+++ b/fabfile/component/kraken.py
@@ -258,13 +258,12 @@ def restart_kraken(instance, wait='serial'):
                Possible values=False or None: restart in parallel, no test
                'serial': restart serially and test
                'parallel': restart in parallel and test
+               'no_test': explicitely skip tests (faster but dangerous)
         The default value is 'serial' because it is the safest scenario
         to restart the krakens of an instance in production.
     """
-    if wait:
-        wait = wait.lower()
-        if wait not in ('serial', 'parallel'):
-            wait = None
+    if wait not in ('serial', 'parallel', 'no_test'):
+        abort(yellow("Error: wait parameter must be serial, parallel or no_test"))
     instance = get_real_instance(instance)
     excluded = instance.name in env.excluded_instances
     # restart krakens of this instance that are also in the eng role,
@@ -275,8 +274,10 @@ def restart_kraken(instance, wait='serial'):
             test_kraken(instance, fail_if_error=False, wait=True, hosts=[host])
     if wait == 'parallel' and not excluded:
         test_kraken(instance, fail_if_error=False, wait=True)
-    if wait and excluded:
+    if wait != 'no_test' and excluded:
         print(yellow("Coverage '{}' has no data, not testing it".format(instance.name)))
+    if wait == 'no_test':
+        print(yellow("Warning Coverage '{}' not tested: parameter wait='no_test'".format(instance.name)))
 
 
 @task

--- a/fabfile/component/kraken.py
+++ b/fabfile/component/kraken.py
@@ -93,7 +93,7 @@ def rollback_instance(instance, test=True):
     instance = get_real_instance(instance)
     execute(swap_data_nav, instance, force=True)
     execute(set_kraken_binary, instance, old=True)
-    execute(restart_kraken, instance, wait=test and env.KRAKEN_RESTART_SCHEME)
+    execute(restart_kraken, instance, wait=env.KRAKEN_RESTART_SCHEME if test else 'no_test')
 
 
 @task

--- a/integration_tests/test_kraken/test_duplicated.py
+++ b/integration_tests/test_kraken/test_duplicated.py
@@ -59,7 +59,7 @@ def test_stop_restart_single_kraken_parallel(duplicated):
 
 
 @skipifdev
-def test_stop_restart_single_kraken_nowait1(duplicated):
+def test_stop_restart_single_kraken_nowait(duplicated):
     _, fabric = duplicated
     with fabric.set_call_tracker('component.kraken.test_kraken') as data:
         _test_stop_restart_kraken(duplicated,
@@ -67,21 +67,7 @@ def test_stop_restart_single_kraken_nowait1(duplicated):
                                  map_stop=krakens_after_stop,
                                  stop_pat=('stop_kraken', ('us-wa', 'fr-ne-amiens')),
                                  start_pat=('component.kraken.restart_kraken', ('us-wa', 'fr-ne-amiens'),
-                                            dict(wait='false'))
-                                 )
-    assert len(data()['test_kraken']) == 0
-
-
-@skipifdev
-def test_stop_restart_single_kraken_nowait2(duplicated):
-    _, fabric = duplicated
-    with fabric.set_call_tracker('component.kraken.test_kraken') as data:
-        _test_stop_restart_kraken(duplicated,
-                                 map_start=nominal_krakens,
-                                 map_stop=krakens_after_stop,
-                                 stop_pat=('stop_kraken', ('us-wa', 'fr-ne-amiens')),
-                                 start_pat=('component.kraken.restart_kraken', ('us-wa', 'fr-ne-amiens'),
-                                            dict(wait=None))
+                                            dict(wait='no_test'))
                                  )
     assert len(data()['test_kraken']) == 0
 
@@ -89,16 +75,16 @@ def test_stop_restart_single_kraken_nowait2(duplicated):
 @skipifdev
 def test_restart_all_krakens(duplicated):
     _, fabric = duplicated
-    with fabric.set_call_tracker('component.kraken.test_kraken',
+    with fabric.set_call_tracker('-component.kraken.test_kraken',
                                  'component.kraken.restart_kraken') as data:
         _test_stop_restart_kraken(duplicated,
                                  map_start=nominal_krakens,
                                  map_stop=krakens_after_stop,
                                  stop_pat=('stop_kraken', ('us-wa', 'fr-ne-amiens')),
-                                 start_pat=('restart_all_krakens', (), dict(wait=False))
+                                 start_pat=('restart_all_krakens', (), dict(wait='parallel'))
                                  )
     assert len(data()['restart_kraken']) == len(fabric.env.instances)
-    assert len(data()['test_kraken']) == 0
+    assert len(data()['test_kraken']) == len(fabric.env.instances)
 
 
 @skipifdev
@@ -307,7 +293,7 @@ def test_upgrade_engine_packages(duplicated):
     assert platform.path_exists('/usr/bin/kraken.old')
 
 
-@skipifdev
+# @skipifdev
 def test_rollback_instance(duplicated):
     platform, fabric = duplicated
 
@@ -325,8 +311,8 @@ def test_rollback_instance(duplicated):
         assert platform.docker_exec('readlink /srv/kraken/{}/kraken'.format(instance), 'host2') == '/usr/bin/kraken'
 
     # we don't want to actually restart the kraken under test
-    with fabric.set_call_tracker('-component.kraken.restart_kraken') as data:
-        value, exception, stdout, stderr = fabric.execute_forked('rollback_instance', 'us-wa')
+    with fabric.set_call_tracker('component.kraken.restart_kraken') as data:
+        value, exception, stdout, stderr = fabric.execute_forked('rollback_instance', 'us-wa', False)
     assert exception is None
     assert stderr == ''
 


### PR DESCRIPTION
because someone can mistakenly call restart_all_kraken with an instance name as positional parameter and this would restart all kraken in prod in parallel, which would result in a massive and general service outage !!!