### PR TITLE
fix deployment artemis

### DIFF
--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -302,7 +302,7 @@ def upgrade_version():
     """
     # upgrade packages anywhere
     execute(upgrade_all_packages)
-    execute(upgrade_tyr)
+    execute(upgrade_tyr, reload=False)
     for instance in env.instances.values():
         execute(tyr.update_ed_db, instance.name)
 


### PR DESCRIPTION
The artemis's deployment uses the "upgrade_version" task which calls "upgrade_tyr" task. This one reload apache by default but if apache is not started before, the task fails.