### PR TITLE
Fix deployment

### DIFF
--- a/fabfile/component/jormungandr.py
+++ b/fabfile/component/jormungandr.py
@@ -53,7 +53,8 @@ from fabtools import require, python
 #          on the resulting naming of tasks, wich can break integration tests
 from fabfile.component import load_balancer
 from fabfile.utils import (_install_packages, _upload_template, get_real_instance,
-                           start_or_stop_with_delay, get_bool_from_cli, show_version)
+                           start_or_stop_with_delay, get_bool_from_cli, show_version,
+                            restart_apache)
 
 
 @task
@@ -133,8 +134,7 @@ def reload_jormun_safe(server, safe=True):
     with settings(host_string=server):
         if env.use_load_balancer and safe:
             load_balancer.disable_node(server)
-        sudo("service apache2 restart")
-        sleep(1)
+        restart_apache()
         if env.use_load_balancer and safe:
             load_balancer.enable_node(server)
 

--- a/fabfile/component/jormungandr.py
+++ b/fabfile/component/jormungandr.py
@@ -133,7 +133,7 @@ def reload_jormun_safe(server, safe=True):
     with settings(host_string=server):
         if env.use_load_balancer and safe:
             load_balancer.disable_node(server)
-        sudo("service apache2 reload")
+        sudo("service apache2 restart")
         sleep(1)
         if env.use_load_balancer and safe:
             load_balancer.enable_node(server)

--- a/fabfile/component/tyr.py
+++ b/fabfile/component/tyr.py
@@ -52,7 +52,7 @@ from fabfile.utils import (_install_packages, _upload_template, update_init, Par
                            start_or_stop_with_delay, supervision_downtime, time_that,
                            get_real_instance, require_directories, require_directory,
                            run_once_per_host, execute_flat, idempotent_symlink, collapse_op,
-                           get_processes, get_bool_from_cli, watchdog_manager)
+                           get_processes, get_bool_from_cli, watchdog_manager, restart_apache)
 
 
 @task
@@ -691,7 +691,7 @@ def reload_tyr_safe(server, safe=True):
     with settings(host_string=server):
         if env.use_load_balancer and safe:
             load_balancer.disable_node(server)
-        sudo("service apache2 restart")
+        restart_apache()
         if env.use_load_balancer and safe:
             load_balancer.enable_node(server)
 

--- a/fabfile/component/tyr.py
+++ b/fabfile/component/tyr.py
@@ -691,7 +691,7 @@ def reload_tyr_safe(server, safe=True):
     with settings(host_string=server):
         if env.use_load_balancer and safe:
             load_balancer.disable_node(server)
-        sudo("service apache2 reload")
+        sudo("service apache2 restart")
         if env.use_load_balancer and safe:
             load_balancer.enable_node(server)
 

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -138,7 +138,7 @@ def upgrade_all(up_tyr=True, up_confs=True, check_version=True, send_mail='no',
     execute(kraken.swap_all_data_nav)
 
     # Upgrade kraken/jormun on first hosts set
-    if not env.roledefs['eng'] and not env.roledefs['ws']:
+    if env.eng_hosts_1 and env.ws_hosts_1:
         env.roledefs['eng'] = env.eng_hosts_1
         env.roledefs['ws'] = env.ws_hosts_1
         if manual_lb:
@@ -155,7 +155,7 @@ def upgrade_all(up_tyr=True, up_confs=True, check_version=True, send_mail='no',
         instance = random.choice(env.instances.values())
         execute(jormungandr.test_jormungandr, get_host_addr(server), instance=instance.name)
 
-    if not env.roledefs['eng'] and not env.roledefs['ws']:
+    if env.eng_hosts_2 and env.ws_hosts_2:
         # Upgrade kraken/jormun on remaining hosts
         env.roledefs['eng'] = env.eng_hosts_2
         env.roledefs['ws'] = env.ws_hosts_2

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -307,7 +307,7 @@ def apt_get_update():
 @task
 def restart_apache():
     start_or_stop_with_delay("apache2", 4000, 500, start=False, only_once=True)
-    start_or_stop_with_delay("apache2", 4000, 500, only_once=env.KRAKEN_START_ONLY_ONCE)
+    start_or_stop_with_delay("apache2", 4000, 500, only_once=True)
 
 
 @task

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -304,6 +304,11 @@ host_app_mapping = dict(
 def apt_get_update():
     sudo('apt-get update')
 
+@task
+def restart_apache():
+    start_or_stop_with_delay("apache2", 4000, 500, start=False, only_once=True)
+    start_or_stop_with_delay("apache2", 4000, 500, only_once=env.KRAKEN_START_ONLY_ONCE)
+
 
 @task
 def get_version(host):


### PR DESCRIPTION
restart = stop + start
reload = remain running + re-read configuration files

"graceful" is better than "reload" because it is waiting the process is finished but need "restart" to kill old process. 

To be sure to restart the service, it is better to stop and start it.