### PR TITLE
add task id to log

### DIFF
--- a/templates/tyr/settings.py.jinja
+++ b/templates/tyr/settings.py.jinja
@@ -35,7 +35,7 @@ LOGGER = {
             'format': 'tyr: [%(name)s] [%(asctime)s] [%(levelname)s] [%(process)s] %(message)s',
         },
         'instance': {
-            'format': '%(name)s: [%(asctime)s] [%(levelname)s] [%(process)s] %(message)s',
+            'format': '%(name)s: [%(asctime)s] [%(levelname)s] [%(process)s] [%(task_id)s] %(message)s',
         }
 
     },


### PR DESCRIPTION
Activate https://github.com/CanalTP/navitia/pull/2068 to have a job id to follow/filter in logs

Might break regex used in Kibana (logstash file)
So Navitia team may only approve.
Devops team will (remove `do_not_merge` tag and ) merge whenever they're ready ( @chbiguereau @Hoshiyo )