### PR TITLE
change used variable on switch_to_first_phase , switch_to_second_phas…

### DIFF
--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -149,7 +149,7 @@ def upgrade_all(up_tyr=True, up_confs=True, check_version=True, send_mail='no',
         if manual_lb:
             raw_input(yellow("Please disable ENG1,3/WS7-9 and enable ENG2,4/WS10-12"))
         else:
-            execute(switch_to_first_phase, env.eng_hosts_1, env.ws_hosts_1, env.ws_hosts_2)
+            execute(switch_to_first_phase, env.eng_pool1, env.ws_hosts_1, env.ws_hosts_2)
     execute(upgrade_kraken, wait=env.KRAKEN_RESTART_SCHEME, up_confs=up_confs, supervision=True)
     if check_dead:
         execute(kraken.check_dead_instances, not_loaded_instances)
@@ -171,7 +171,7 @@ def upgrade_all(up_tyr=True, up_confs=True, check_version=True, send_mail='no',
         if manual_lb:
             raw_input(yellow("Please enable ENG1,3/WS7-9 and disable ENG2,4/WS10-12"))
         else:
-            execute(switch_to_second_phase, env.eng_hosts_1, env.eng_hosts_2,
+            execute(switch_to_second_phase, env.eng_pool1, env.eng_pool2,
                     env.ws_hosts_1,  env.ws_hosts_2)
         execute(upgrade_jormungandr, reload=False, up_confs=up_confs)
         # need restart apache without using upgrade_jormungandr task previously
@@ -193,7 +193,7 @@ def upgrade_all(up_tyr=True, up_confs=True, check_version=True, send_mail='no',
         env.roledefs['eng'] = env.eng_hosts
         if not manual_lb:
             #execute(enable_nodes, env.eng_hosts)
-            execute(enable_kraken_haproxy, env.eng_hosts)
+            execute(enable_kraken_haproxy, env.eng_names)
 
     # start tyr_beat even if up_tyr is False
     execute(tyr.start_tyr_beat)


### PR DESCRIPTION
Hotfix for the next  delivery of navitia2 in production.

The old values of variable return root@mut-prd-eng1.canaltp.prod instead of mut-prd-eng1.canaltp.prod

I changed eng_hosts_1 by eng_pool1, eng_hosts_2 by eng_pool2 and eng_hosts by eng_names