### PR TITLE
DEVOPP-1299-add-LimitNOFILE-systemd

### DIFF
--- a/templates/kraken/systemd_kraken.jinja
+++ b/templates/kraken/systemd_kraken.jinja
@@ -7,6 +7,7 @@ Description=start kraken_{{instance}}
 After=network.target
 
 [Service]
+LimitNOFILE=49152
 Type=simple
 ExecStart={{kraken_base_conf}}/{{instance}}/kraken
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
Grow up  the number  of  filedescriptor ( persistent connexion ) used by kraken 

It's necessary transilien and vianavigo 
