### PR TITLE
Add configuration to jormungandr for using uwsgi cache

### DIFF
--- a/fabfile/env/platforms.py
+++ b/fabfile/env/platforms.py
@@ -282,6 +282,8 @@ env.jormungandr_redis_password = None
 env.jormungandr_enable_redis = False
 env.jormungandr_cache_timeout = 600
 
+env.jormungandr_use_uwsgi_cache = False
+
 # stat_persitor and rt (?)
 env.jormungandr_broker_username = 'guest'
 env.jormungandr_broker_password = 'guest'

--- a/templates/jormungandr/settings.py.jinja
+++ b/templates/jormungandr/settings.py.jinja
@@ -111,6 +111,15 @@ CACHE_CONFIGURATION = {
     'TIMEOUT_SIRI': {{env.jormungandr_siri_cache_timeout}},
 }
 
+{% if env.jormungandr_use_uwsgi_cache %}
+MEMORY_CACHE_CONFIGURATION = {
+    'CACHE_TYPE': 'uwsgi',
+    'CACHE_UWSGI_NAME': 'jormungandr',
+    'TIMEOUT_AUTHENTICATION': 30,
+    'TIMEOUT_PARAMS': 30,
+}
+{% endif %}
+
 
 AUTOCOMPLETE_SYSTEMS = {
 {% if env.bragi_url %}


### PR DESCRIPTION
https://uwsgi-docs.readthedocs.io/en/latest/Caching.html

Once activated this cache add a first layer used **before** redis that is shared between all the processes of an host. 
This will sightly increase performance but mostly reduce the number of call to redis.