### PR TITLE
Add another handler for logging in jormungandr

### DIFF
--- a/templates/jormungandr/settings.py.jinja
+++ b/templates/jormungandr/settings.py.jinja
@@ -66,6 +66,12 @@ LOGGER = {
             "backupCount": "5",
             "filters": ['IdFilter']
         },
+        'stream': {
+            'level': "{{env.jormungandr_log_level}}",
+            'class': 'logging.StreamHandler',
+            'formatter': 'json',
+            'filters': ['IdFilter']
+        },
         {% if env.use_syslog %}
         'syslog': {
         'level': "{{env.jormungandr_log_level}}",


### PR DESCRIPTION
This logger writes to stdout.
When jormun is launched by uswgi these log are caught by uwsgi and
write to the log file configured in it.
By itself this PR doesn't do anything as this new handler won't be used
until `env.jormungandr_default_handler` is set.