### PR TITLE
Set Rabbimq with default original ones

### DIFF
--- a/fabfile/env/platforms.py
+++ b/fabfile/env/platforms.py
@@ -196,10 +196,10 @@ env.rabbitmq_port_api = 15672
 
 
 env.rabbitmq_stats_host = 'localhost'
-env.rabbitmq_stats_port = '5672'
-env.rabbitmq_stats_user = 'stat_write'
-env.rabbitmq_stats_pass = 'pass'
-env.rabbitmq_stats_vhost = 'nav2logs'
+env.rabbitmq_stats_port = 5672
+env.rabbitmq_stats_user = 'user'
+env.rabbitmq_stats_pass = 'pwd'
+env.rabbitmq_stats_vhost = '/'
 
 
 env.stat_broker_exchange = 'stat_persistor_exchange'


### PR DESCRIPTION
The default values added for the dedicated rabbimq stats will break for the environements with no separated Rqbbitmq (like `Dev`).

This PR set the default values back to what they were.