### PR TITLE
[Tyr] Split brokers used for Celery and Kraken

### DIFF
--- a/fabfile/env/platforms.py
+++ b/fabfile/env/platforms.py
@@ -207,7 +207,6 @@ env.rabbitmq_tyr_host = 'localhost'
 env.rabbitmq_tyr_user = 'guest'
 env.rabbitmq_tyr_pass = 'guest'
 env.rabbitmq_tyr_vhost = '/'
-env.rabbitmq_tyr_exchange = 'navitia'
 
 
 # STATS 

--- a/templates/tyr/instance.ini.jinja
+++ b/templates/tyr/instance.ini.jinja
@@ -17,7 +17,7 @@ is-free          = false
 
 rt-topics = ,
 
-exchange-name    = {{env.rabbitmq_tyr_exchange}}
+exchange-name    = {{env.rabbitmq_kraken_exchange}}
 
 [database]
 host     = {{env.ed_postgresql_database_host}}

--- a/templates/tyr/settings.py.jinja
+++ b/templates/tyr/settings.py.jinja
@@ -11,6 +11,7 @@ import logging
 #the default vhost is "/" so the URL end with *two* slash
 #http://docs.celeryproject.org/en/latest/configuration.html#std:setting-BROKER_URL
 CELERY_BROKER_URL = 'amqp://{{env.rabbitmq_tyr_user}}:{{env.rabbitmq_tyr_pass}}@{{env.rabbitmq_tyr_host}}:{{env.rabbitmq_tyr_port}}/{{env.rabbitmq_tyr_vhost}}'
+KRAKEN_BROKER_URL = 'amqp://{{env.rabbitmq_kraken_user}}:{{env.rabbitmq_kraken_pass}}@{{env.rabbitmq_kraken_host}}:{{env.rabbitmq_kraken_port}}/{{env.rabbitmq_kraken_vhost}}'
 
 #URI for postgresql
 # postgresql://<user>:<password>@<host>:<port>/<dbname>


### PR DESCRIPTION
Celery and Kraken are using Rabbimq, but for complete different purpose.
The service used to be hosted on the exact same machine, which is not
the case anymore.

Hence the need to address 2 different brokers:
* One for Tyr to interact with Celery: CELERY_BROKER_URL
* One for Tyr to interact with the Krakens: KRAKEN_BROKER_URL