### PR TITLE
Github Actions: Retreive the last Navitia Debian packages in success

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,9 +2,9 @@
 
 ## retreive_debian_packages_from_github 
 
-**Github Actions** is capable to create **artifacts** from a specific job.\n
-Artifacts can be downloaded via the github API.\n
-We want to reteive the **last Navitia Debian packages** (in *success*) compressed in a zip file.\n
+**Github Actions** is capable to create **artifacts** from a specific job.<br>
+Artifacts can be downloaded via the github API.<br>
+We want to reteive the **last Navitia Debian packages** (in *success*) compressed in a zip file.<br>
 To perform it, the script does:
 - Find the concerned workflow (id)
 - Retreive the last run (in success) of the workflow

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,32 @@
+# Extra Tools used to deploy
+
+## retreive_debian_packages_from_github 
+
+Github Actions is capable to create artifacts from a specific job.
+Artifacts can be downloaded via the github API
+We want to reteive the last Navitia Debian packages (in success) compressed in a zip file.
+To perform it, the script does:
+- Find the concerned workflow (id)
+- Retreive the last run (in success) of the workflow
+- Dowmload the associated artifacts (in a zip file)
+
+script type : python 2
+
+### How to install 
+
+```
+# Create your own virtual env
+pip install -r requirements.txt
+```
+
+### How to run it 
+
+```
+# Help
+pythonn2.7 retreive_debian_packages_from_github.py -h
+
+# example
+pythonn2.7 retreive_debian_packages_from_github.py -u {GithubUser} -t {GithubToken} -w {workflow name} -a {artifacts.zip} -o {output_path}
+```
+
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,9 +2,9 @@
 
 ## retreive_debian_packages_from_github 
 
-Github Actions is capable to create artifacts from a specific job.
-Artifacts can be downloaded via the github API
-We want to reteive the last Navitia Debian packages (in success) compressed in a zip file.
+**Github Actions** is capable to create **artifacts** from a specific job.\n
+Artifacts can be downloaded via the github API.\n
+We want to reteive the **last Navitia Debian packages** (in *success*) compressed in a zip file.\n
 To perform it, the script does:
 - Find the concerned workflow (id)
 - Retreive the last run (in success) of the workflow
@@ -16,6 +16,7 @@ script type : python 2
 
 ```
 # Create your own virtual env
+# and install dependencies
 pip install -r requirements.txt
 ```
 
@@ -25,7 +26,7 @@ pip install -r requirements.txt
 # Help
 pythonn2.7 retreive_debian_packages_from_github.py -h
 
-# example
+# Example
 pythonn2.7 retreive_debian_packages_from_github.py -u {GithubUser} -t {GithubToken} -w {workflow name} -a {artifacts.zip} -o {output_path}
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,12 +2,12 @@
 
 ## retreive_debian_packages_from_github 
 
-**Github Actions** is capable to create **artifacts** from a specific job.<br>
+**Github Actions** is capable of creating **artifacts** from a specific job.<br>
 Artifacts can be downloaded via the github API.<br>
-We want to reteive the **last Navitia Debian packages** (in *success*) compressed in a zip file.<br>
+We want to retrieve the **last Navitia Debian packages** (in *success*) compressed in a zip file.<br>
 To perform it, the script does:
-- Find the concerned workflow (id)
-- Retreive the last run (in success) of the workflow
+- Find the related workflow (id)
+- Retrieve the last run (in success) of the workflow
 - Dowmload the associated artifacts (in a zip file)
 
 script type : python 2

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+requests
+wget

--- a/scripts/retreive_debian_packages_from_github.py
+++ b/scripts/retreive_debian_packages_from_github.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+# Title: Retreive Navitia Debian Packages from Github
+#
+# Github Actions is capable to create artifacts from a specific job.
+# Artifacts can be downloaded via the github API
+# We want to reteive the last Navitia Debian packages (in success) compressed in a zip file.
+# To perform it, the script does:
+# - Find the concerned workflow (id)
+# - Retreive the last run (in success) of the workflow
+# - Dowmload the associated artifacts (in a zip file)
+
+import logging
+import json
+import requests
+import wget
+import sys
+import os
+import argparse
+
+DEFAULT_WORKFLOW_NAME = "Build Navitia Packages For Dev"
+DEFAULT_OUTPUT_PATH = "."
+DEFAULT_ARTIFACTS_NAME = "artifacts.zip"
+
+class GithubArtifactsReceiver:
+    def __init__(self, github_user, github_token, workflow_name=DEFAULT_WORKFLOW_NAME, artifacts_name=DEFAULT_ARTIFACTS_NAME, artifacts_output_path=DEFAULT_OUTPUT_PATH):
+        self.github_user = github_user
+        self.github_token = github_token
+        self.workflow_name = workflow_name
+        self.artifacts_output_path = artifacts_output_path
+        self.artifacts_name = artifacts_name
+        self.old_artifacts_to_remove = self.artifacts_output_path + "/" + self.artifacts_name
+        self.url_header = "https://" + github_user +  ":" + github_token + "@"
+        self.workflows_url = self.url_header + "api.github.com/repos/CanalTP/navitia/actions/workflows"
+        self.runs_url = self.url_header + "api.github.com/repos/CanalTP/navitia/actions/workflows/"
+        self.logger = logging.getLogger('github artifacts receiver')
+        self._config_logger()
+        self.logger.info("load artifacts receiver with github_user={}, github_token={}, workflow_name={}, artifacts_name={}, output_path={}".format(self.github_user, self.github_token, self.workflow_name, self.artifacts_name, self.artifacts_output_path))
+
+
+    def retreive_workflow_id(self):
+        """ Retreive workflow id from Build Navitia Package """
+        resp = self.call(self.workflows_url)
+        for workflow in resp["workflows"]:
+            if workflow["name"] == self.workflow_name:
+                self.logger.info("workflow id for {} is {}".format(self.workflow_name, workflow["id"]))
+                return workflow["id"]
+        self.logger.error("workflow name={}, does not exist".format(self.workflow_name))
+        sys.exit("workflow does not exist")
+
+
+    def retreive_artifacts_link_from_last_run(self, workflow_id):
+        """ Retreive artifacts link from the last run """
+        resp = self.call(self.runs_url + str(workflow_id) + "/runs")
+        total_count = resp["total_count"]
+        for workflow_run in resp["workflow_runs"]:
+            if workflow_run["run_number"] == total_count:
+                if workflow_run["conclusion"] != "success":
+                    self.logger.error("the last job, id {}, is not success".format(workflow_run["id"]))
+                    sys.exit("the last job is not success")
+                self.logger.info("run id={} in success with artifacts url {}".format(workflow_run["id"], workflow_run["artifacts_url"]))
+                return (workflow_run["artifacts_url"], workflow_run["id"])
+        self.logger.error("can not find last run within workflow {}".format(self.workflow_name))
+        sys.exit("artifacts url does not exist")
+
+
+    def download_artifacts(self, artifacts_url, run_id):
+        """ Download artifacts """
+        artifacts_url = self.url_header + artifacts_url.replace('https://', '')
+        resp = self.call(artifacts_url)
+        if resp["total_count"] == 0:
+            self.logger.error("No artifacts available for run {}".format(run_id))
+            self.logger.error("Artifacts: https://api.github.com/repos/CanalTP/navitia/actions/runs/{}/artifacts".format(run_id))
+            sys.exit()
+        if resp["total_count"] > 1:
+            self.logger.error("There must be only one artifacts - run id {}".format(run_id))
+            self.logger.error("Artifacts: https://api.github.com/repos/CanalTP/navitia/actions/runs/{}/artifacts".format(run_id))
+            sys.exit()
+        zip_url = self.url_header + resp["artifacts"][0]["archive_download_url"].replace('https://', '')
+
+        # Remove old artifacts with the same name if exist
+        if os.path.isfile(self.old_artifacts_to_remove):
+            self.logger.info("remove old artifacts - {}".format(self.old_artifacts_to_remove))
+            os.remove(self.old_artifacts_to_remove)
+
+        filename = ""
+        self.logger.info("download {}".format(zip_url))
+        filename = wget.download(zip_url, self.artifacts_output_path + "/" + self.artifacts_name)
+        self.logger.info("")
+        self.logger.info("File {} downloaded".format(filename))
+
+
+    def _config_logger(self):
+        self.logger.setLevel(logging.DEBUG)
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        ch.setFormatter(formatter)
+        self.logger.addHandler(ch)
+
+
+    def call(self, url):
+        self.logger.info("call {}".format(url))
+        r = requests.get(url)
+        return json.loads(r.text.encode('utf-8'))
+
+
+    def check_github_api(self):
+        self.logger.info("check github actions API")
+        r = requests.get(self.workflows_url)
+        if r.status_code == 200:
+            self.logger.info("github API status 200")
+        else:
+            self.logger.error("github API status {}".format(r.status_code))
+            self.logger.error("stop process")
+            sys.exit("github API status != 200")
+
+
+    def run(self):
+        workflow_id = self.retreive_workflow_id()
+        artifacts_url, run_id = self.retreive_artifacts_link_from_last_run(workflow_id)
+        self.download_artifacts(artifacts_url, run_id)
+
+
+def config_logger():
+    logger = logging.getLogger('retreive debian package from github')
+    logger.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+    return logger
+
+def parse_args(parser, logger):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-u", dest="github_user", help="Github user to call Github API (mandatory)")
+    parser.add_argument("-t", dest="github_token", help="Github token to call Github API (mandatory)")
+    parser.add_argument("-w", dest="workflow_name", help="Github Workflow name", default=DEFAULT_WORKFLOW_NAME)
+    parser.add_argument("-a", dest="artifacts_name", help="Artifacts name", default=DEFAULT_ARTIFACTS_NAME)
+    parser.add_argument("-o", dest="output_dir", help="Output path", default=DEFAULT_OUTPUT_PATH)
+    args = parser.parse_args()
+
+    if not args.github_user:
+        logger.error("Github user is a mandatory parameter")
+        logger.error("Please fill -u parameter")
+        sys.exit("Github user is a mandatory parameter")
+    if not args.github_user:
+        logger.error("Github token is a mandatory parameter")
+        logger.error("Please fill -t parameter")
+        sys.exit("Github token is a mandatory parameter")
+
+    return args
+
+
+def main():
+    logger = config_logger()
+    logger.info("start process")
+
+    args = parse_args(argparse.ArgumentParser(), logger)
+
+    artifacts_receiver = GithubArtifactsReceiver(args.github_user, args.github_token, args.workflow_name, args.artifacts_name, args.output_dir)
+    artifacts_receiver.check_github_api()
+    artifacts_receiver.run()
+
+    logger.info("finish process")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script is capable to download the **last artifact** linked to a job, if the job is **in success.**
It is saved inside navitia fabric because we want to use it in adequacy with the fabric.
The deploy needs Navitia Debian packages Artifacts (from **Github Actions**) and it can provide it.

**Example**
In our context, we can use it like this : 

- replace in the _deploy_navitia_on_dev_ Jenkins job, the :
![navitia_dev_artifacts](https://user-images.githubusercontent.com/32099204/75757930-8ab42b00-5d33-11ea-8c2e-ab1261eaf674.png)
by the following command line :
```
python2.7 retreive_debian_packages_from_github.py -u jenkinsctp -t GITHUB_TOKEN -w "Build Navitia Packages" -a artifacts.zip -o "./.."
```
we directly download the artifacts from https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages%22

the trace
```
2020-03-03 09:47:10,610 - retreive debian package from github - INFO - start process
2020-03-03 09:47:10,611 - github artifacts receiver - INFO - load artifacts receiver with github_user=jenkinsctp, github_token=Token, workflow_name=Build Navitia Packages, artifacts_name=artifacts.zip, output_path=./..
2020-03-03 09:47:10,611 - github artifacts receiver - INFO - check github actions API
2020-03-03 09:47:10,908 - github artifacts receiver - INFO - github API status 200
2020-03-03 09:47:10,908 - github artifacts receiver - INFO - call https://jenkinsctp:token@api.github.com/repos/CanalTP/navitia/actions/workflows
2020-03-03 09:47:11,221 - github artifacts receiver - INFO - workflow id for Build Navitia Packages is 514730
2020-03-03 09:47:11,222 - github artifacts receiver - INFO - call https://jenkinsctp:token@api.github.com/repos/CanalTP/navitia/actions/workflows/514730/runs
2020-03-03 09:47:13,049 - github artifacts receiver - INFO - run id=48255845 in success with artifacts url https://api.github.com/repos/CanalTP/navitia/actions/runs/48255845/artifacts
2020-03-03 09:47:13,049 - github artifacts receiver - INFO - call https://jenkinsctp:token@api.github.com/repos/CanalTP/navitia/actions/runs/48255845/artifacts
2020-03-03 09:47:13,311 - github artifacts receiver - INFO - download https://jenkinsctp:token@api.github.com/repos/CanalTP/navitia/actions/artifacts/2430194/zip
2020-03-03 09:47:27,921 - github artifacts receiver - INFO - File ./../artifacts.zip downloaded
2020-03-03 09:47:27,921 - retreive debian package from github - INFO - finish process
```