### PR TITLE
timeout error HTTPConnectionPool - Read timed out. (read timeout=2)

### DIFF
--- a/fabfile/component/kraken.py
+++ b/fabfile/component/kraken.py
@@ -331,7 +331,7 @@ def _test_kraken(query, fail_if_error=True):
     """
     print("calling : {}".format(query))
     try:
-        response = requests.get(query, timeout=2)
+        response = requests.get(query, timeout=5)
     except requests.exceptions.Timeout as t:
         print("timeout error {}".format(t))
         if fail_if_error:


### PR DESCRIPTION
Set timeout value to 5 instead of 2