### PR TITLE
[NAV2] [ALL] [>=8.2] Naive fix of Jinja requirements breaking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Fabric3==1.11.1.post1
-Jinja==2.10.1
-Jinja2==2.7.3
+Jinja2==2.10.1
 MarkupSafe==0.23
 argparse==1.2.1
 ecdsa==0.13.3


### PR DESCRIPTION
As Jinja and Jinja2 are now **very** separate :
* `Jinja` holds versions < 2
* `Jinja2` versions >= 2.

Review carefully: Dont know why both were required (and what could break).
Another solution is to step back to Jinja==1.2 (last version), reverting part of https://github.com/CanalTP/fabric_navitia/pull/304

My suggestion:
* Merge it before any deployment not-on-prod, let dev nightly deploy test it, then use it for not_on_prod deployment.
* If anything breaks, go back to `Jinja==1.2` and look for a better solution after.