### PR TITLE
Do not crash on invalid kraken instance 

### DIFF
--- a/fabfile/component/kraken.py
+++ b/fabfile/component/kraken.py
@@ -239,7 +239,7 @@ def get_not_loaded_instances_per_host():
             request = 'http://{}:{}/{}/?instance={}'.format(host, env.kraken_monitor_port,
                                                             env.kraken_monitor_location_dir, instance.name)
             result = _test_kraken(request, fail_if_error=False)
-            if not result or result['status'] == 'timeout' or result['loaded'] is False:
+            if not result or 'error' in result or result['status'] == 'timeout' or result['loaded'] is False:
                 not_loaded.append(instance_host(instance=instance.name, host=host))
 
     if not_loaded:


### PR DESCRIPTION
In the task `get_not_loaded_instances_per_host() ` the result of the request to kraken-monitor can be `{"error": ["instance invalid"]}` (see [here](https://github.com/CanalTP/navitia/blob/f48e96b6cc20bdf4916e3af4a497e15db6e11b25/source/monitor/monitor_kraken/app.py#L58)), and when this happens the task crash.
This PR aims at handling this case without crashing.