### PR TITLE
[JenkinsPipe] core team - deploy navitia jenkins pipe

### DIFF
--- a/.jenkins/deploy_navitia
+++ b/.jenkins/deploy_navitia
@@ -1,0 +1,148 @@
+pipeline {
+    agent {
+        docker {
+            image 'ubuntu:18.04'
+            args '--user root'
+        }
+    }
+    triggers {
+        parameterizedCron('''
+            * 1 * * * %PLATFORM=artemis_debian8
+            * 3 * * * %PLATFORM=dev_debian8
+        ''')
+    }
+    stages {
+        stage('Install extra packages') {
+            steps {
+                sh '''
+                    echo "install extra packages"
+                    apt update
+                    apt install -y curl git unzip python python-pip
+                '''
+            }
+        }
+        stage('Debian packages name') {
+            steps {
+                script {
+                    if (env.PLATFORM == 'dev_debian8') {
+                        env.NAVITIA_DEBIAN_PACKAGES = "navitia-debian8-packages.zip"
+                    } else if (env.PLATFORM == 'dev_debian10') {
+                        env.NAVITIA_DEBIAN_PACKAGES = "navitia-debian10-packages.zip"
+                    } else if (env.PLATFORM == 'artemis_debian8') {
+                        env.NAVITIA_DEBIAN_PACKAGES = "navitia-debian8-packages.zip"
+                    } else {
+                        echo 'selected platform not available'
+                        sh 'exit 1'
+                    }
+                }
+                sh 'echo "Platform" ${PLATFORM} "selected"'
+                sh 'echo ${NAVITIA_DEBIAN_PACKAGES} "is selected"'
+            }
+        }
+        stage('Retreive core_team_ci_tools') {
+            steps {
+                withCredentials([string(credentialsId: 'jenkins-core-github-access-token', variable: 'GITHUB_TOKEN')]) {
+                    sh 'rm -rf core_team_ci_tools && mkdir -p core_team_ci_tools'
+                    sh ' git clone https://jenkins-kisio-core:$GITHUB_TOKEN@github.com/CanalTP/core_team_ci_tools.git'
+                }
+            }
+        }
+        stage('Install requirement to retreive Github artifacts') {
+            steps {
+                sh '''
+                    pip install -r core_team_ci_tools/github_artifacts/requirements.txt
+                '''
+            }
+        }
+        stage('process navitia debian packages') {
+            steps {
+                withCredentials([string(credentialsId: 'jenkins-core-github-access-token', variable: 'GITHUB_TOKEN')]) {
+                    sh '''
+                        echo "retreive debian packages for github_artifacts (workflow : Build Navitia Packages For Dev Multi Distributions)"
+                        python core_team_ci_tools/github_artifacts/github_artifacts.py -o CanalTP -r navitia -t $GITHUB_TOKEN -w build_navitia_packages_for_dev_multi_distribution.yml -a ${NAVITIA_DEBIAN_PACKAGES}
+                    '''
+                }
+            }
+        }
+        stage('unzip navitia debian packages bundle') {
+            steps {
+                sh '''
+                    # unzip github artifacts (${NAVITIA_DEBIAN_PACKAGES})
+                    echo "Unzip artifacts"
+                    unzip -q ${NAVITIA_DEBIAN_PACKAGES}
+                    # unzip artifacts (navitia_debian_packages.zip)
+                    echo "Unzip .deb"
+                    unzip -q navitia_debian* 2>&1
+                '''
+            }
+        }
+        stage('Retreive deployment configuration') {
+            steps {
+                withCredentials([string(credentialsId: 'jenkins-core-github-access-token', variable: 'GITHUB_TOKEN')]) {
+                    sh 'rm -rf navitia_deployment_conf && mkdir -p navitia_deployment_conf' 
+                    sh ' git clone https://jenkins-kisio-core:$GITHUB_TOKEN@github.com/CanalTP/navitia_deployment_conf.git'
+                }
+            }
+        }
+        stage('Install requirement for fabric deployment') {
+            steps {
+                sh '''
+                    pip install -r requirements.txt --exists-action w
+                '''
+            }
+        }
+        stage('Run deployment') {
+            steps {
+                sshagent(credentials : ['jenkins-core-ssh']) {
+                    script {
+                        if (env.PLATFORM == 'dev_debian8') {
+                            echo 'deploy on dev - debian 8 platform'
+                            sh '''
+                                PYTHONPATH=navitia_deployment_conf/ python2 -u -m fabric use:dev upgrade_all:check_version=False
+                            '''
+                        } else if (env.PLATFORM == 'dev_debian10') {
+                            echo 'deploy on dev - debian 10 platform'
+                            echo 'Not implemented yet !!!!!'
+                            sh 'exit 1'
+                        } else if (env.PLATFORM == 'artemis_debian8') {
+                            echo 'deploy on artemis - debian 8 platform'
+                            sh '''
+                                PYTHONPATH=navitia_deployment_conf/ python2 -u -m fabric use:artemis upgrade_version
+                                PYTHONPATH=navitia_deployment_conf/ python2 -u -m fabric use:artemis update_all_configurations:restart=false
+                            '''
+                        } else {
+                            echo 'platform not available'
+                        }
+                    }
+                }
+            }
+        }
+        stage('Invoke Artemis job after a deploy on Artemis platform') {
+            when {
+                expression { env.PLATFORM == 'artemis_debian8' }
+            }
+            steps {
+                build (job: 'artemis', propagate: false)
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+        }
+        cleanup {
+            sh '''
+                echo "remove downloaded artifacts"
+                rm -rf navitia-*
+                rm -rf *.zip
+            '''
+        }
+        failure {
+            withCredentials([string(credentialsId: 'navitia_core_team_slack_chan', variable: 'NAVITIA_CORE_TEAM_SLACK_CHAN')]) {
+                sh '''
+                    curl -X POST -H 'Content-type: application/json' --data '{"text":":warning: Deploy Navitia is failed. See https://jenkins-core.canaltp.fr/job/deploy-navitia/"}' $NAVITIA_CORE_TEAM_SLACK_CHAN
+                '''
+            }
+        }
+    }
+}

--- a/.jenkins/deploy_navitia
+++ b/.jenkins/deploy_navitia
@@ -7,7 +7,6 @@ pipeline {
     }
     triggers {
         parameterizedCron('''
-            * 1 * * * %PLATFORM=artemis_debian8
             * 3 * * * %PLATFORM=dev_debian8
         ''')
     }
@@ -28,8 +27,6 @@ pipeline {
                         env.NAVITIA_DEBIAN_PACKAGES = "navitia-debian8-packages.zip"
                     } else if (env.PLATFORM == 'dev_debian10') {
                         env.NAVITIA_DEBIAN_PACKAGES = "navitia-debian10-packages.zip"
-                    } else if (env.PLATFORM == 'artemis_debian8') {
-                        env.NAVITIA_DEBIAN_PACKAGES = "navitia-debian8-packages.zip"
                     } else {
                         echo 'selected platform not available'
                         sh 'exit 1'
@@ -104,25 +101,11 @@ pipeline {
                             echo 'deploy on dev - debian 10 platform'
                             echo 'Not implemented yet !!!!!'
                             sh 'exit 1'
-                        } else if (env.PLATFORM == 'artemis_debian8') {
-                            echo 'deploy on artemis - debian 8 platform'
-                            sh '''
-                                PYTHONPATH=navitia_deployment_conf/ python2 -u -m fabric use:artemis upgrade_version
-                                PYTHONPATH=navitia_deployment_conf/ python2 -u -m fabric use:artemis update_all_configurations:restart=false
-                            '''
                         } else {
                             echo 'platform not available'
                         }
                     }
                 }
-            }
-        }
-        stage('Invoke Artemis job after a deploy on Artemis platform') {
-            when {
-                expression { env.PLATFORM == 'artemis_debian8' }
-            }
-            steps {
-                build (job: 'artemis', propagate: false)
             }
         }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Fabric3==1.11.1.post1
+Jinja==1.2
 Jinja2==2.10.1
 MarkupSafe==0.23
 argparse==1.2.1


### PR DESCRIPTION
### Goal
Add a new jenkins pipe to deploy Navitia on Dev with the new Jenkins CI.
It was a lonng road to arrive here with many obstacles.
Now it works !

- With a docker environment for avoiding to pollute de agent machine. Ubuntu 18.0' and not 20.04 because of specific python 2 libraries. Not with a classic python2 imagine because we need more for other action unzip, curl, etc...
- Add a cron trigger to be compliant with the job https://ci.navitia.io/job/deploy_navitia_on_dev_from_github/ in the old CI. The deploy on Dev is during the night
- Use an external script to retreive debian packages from github actions https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev+Multi+Distributions%22
- Ready to use a dev debian10 platform when it will be ready poke @xlqian 