### PR TITLE
[Jenkins] Choose the good GA job to publish

### DIFF
--- a/.jenkins/publish_navitia_packages
+++ b/.jenkins/publish_navitia_packages
@@ -50,8 +50,8 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'jenkins-core-github-access-token', variable: 'GITHUB_TOKEN')]) {
                     sh '''
-                        echo "retreive debian packages for github_artifacts (workflow : Build Navitia Packages For Dev Multi Distributions)"
-                        python core_team_ci_tools/github_artifacts/github_artifacts.py -o CanalTP -r navitia -t $GITHUB_TOKEN -w build_navitia_packages_for_dev_multi_distribution.yml -a ${NAVITIA_DEBIAN_PACKAGES}
+                        echo "retreive debian packages for github_artifacts (workflow : Build Navitia Packages For Release)"
+                        python core_team_ci_tools/github_artifacts/github_artifacts.py -o CanalTP -r navitia -t $GITHUB_TOKEN -w build_navitia_packages_for_release.yml -a ${NAVITIA_DEBIAN_PACKAGES}
                     '''
                 }
             }


### PR DESCRIPTION
Simple issue : Choose the good Github Actions  job to publish (this is release packages)