### PR TITLE
CI: waiting GA job to load packages

### DIFF
--- a/.jenkins/publish_navitia_packages
+++ b/.jenkins/publish_navitia_packages
@@ -51,7 +51,7 @@ pipeline {
                 withCredentials([string(credentialsId: 'jenkins-core-github-access-token', variable: 'GITHUB_TOKEN')]) {
                     sh '''
                         echo "retreive debian packages for github_artifacts (workflow : Build Navitia Packages For Release)"
-                        python core_team_ci_tools/github_artifacts/github_artifacts.py -o CanalTP -r navitia -t $GITHUB_TOKEN -w build_navitia_packages_for_release.yml -a ${NAVITIA_DEBIAN_PACKAGES}
+                        python core_team_ci_tools/github_artifacts/github_artifacts.py -o CanalTP -r navitia -t $GITHUB_TOKEN -w build_navitia_packages_for_release.yml -a ${NAVITIA_DEBIAN_PACKAGES} -b release --waiting
                     '''
                 }
             }


### PR DESCRIPTION
We need to wait until the GA job to create packages has finish (we trig the jenskins job but sometimes debian10 or debian 9 have not finish)
The option already exists inside  `python core_team_ci_tools/github_artifacts/github_artifacts.py` script.
We just need to active the option for release branch