### PR TITLE
Revert "[NAV2][ALL] Load all krakens of each instance in parallel"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ simplejson==3.6.3
 wsgiref==0.1.2
 -e git+https://github.com/CanalTP/fabtools.git#egg=fabtools-master
 semver==2.2.1
-future==0.15.2
-futures==3.3.0


### PR DESCRIPTION
Due to issues on deployment, for production, we will revert.

Once deployed in production, we will re-revert again, in order to let @kadhikari work on improvments