### PR TITLE
[CI] - fix navitia packages publishing

### DIFF
--- a/.jenkins/publish_navitia_packages
+++ b/.jenkins/publish_navitia_packages
@@ -11,7 +11,7 @@ pipeline {
                 sh '''
                     echo "install extra packages"
                     apt update
-                    apt install -y curl git unzip python python-pip
+                    apt install -y curl git unzip python python3-pip
                 '''
             }
         }


### PR DESCRIPTION
Fix the issue

```
09:59:30  Package python-pip is not available, but is referred to by another package.
09:59:30  This may mean that the package is missing, has been obsoleted, or
09:59:30  is only available from another source
09:59:30  However the following packages replace it:
09:59:30    python3-pip
09:59:30  
09:59:30  E: Package 'python-pip' has no installation candidate
```