### PR TITLE
[PROD]: Revert Call all krakens in parallel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ simplejson==3.6.3
 wsgiref==0.1.2
 -e git+https://github.com/CanalTP/fabtools.git#egg=fabtools-master
 semver==2.2.1
-future==0.15.2
-futures==3.3.0


### PR DESCRIPTION
For verification, kraken.py should be as in the version : https://github.com/CanalTP/fabric_navitia/blob/5dee8d029d5c527c7f65db03bb351d8341e166bc/fabfile/component/kraken.py

This corresponds to the correction of @pbench committed on 14 Oct 2020
https://github.com/CanalTP/fabric_navitia/commits/5dee8d029d5c527c7f65db03bb351d8341e166bc/fabfile/component/kraken.py