### PR TITLE
[CI] do not trigger artemis_old after deploy

### DIFF
--- a/.jenkins/deploy_navitia
+++ b/.jenkins/deploy_navitia
@@ -106,7 +106,6 @@ pipeline {
                                 PYTHONPATH=navitia_deployment_conf/ python2 -u -m fabric use:artemis upgrade_version
                                 PYTHONPATH=navitia_deployment_conf/ python2 -u -m fabric use:artemis update_all_configurations:restart=false
                             '''
-                            build job: 'artemis_old', wait: false
                         } else if (env.PLATFORM == 'dev_debian10') {
                             echo 'deploy on dev - debian 10 platform'
                             echo 'Not implemented yet !!!!!'


### PR DESCRIPTION
We now rely on Artemis_NG to perform Navitia's integration tests, so triggering Artemis_Old is not needed anymore.
